### PR TITLE
Address CRC

### DIFF
--- a/Documentation/protocol.txt
+++ b/Documentation/protocol.txt
@@ -26,7 +26,7 @@ Frames zusammengefasst werden. Ein Datenpaket besteht aus 2 Bytes zu je
 | Payload      | PC | ST | CRC |
 +--------------+---------------+
 
- Payload: 8 Bits Opcode oder Daten
+ Payload: 8 Bits Opcode+CRC oder Daten
  PC:      3 Bits
  ST:      2 Bits
  CRC:     3 Bits
@@ -56,7 +56,7 @@ Frames zusammengefasst werden. Ein Datenpaket besteht aus 2 Bytes zu je
   ]
 
 Wenn ST=2 ist, enthält das Daten-Byte ein 8-Bit Command.
- 
+
  
 Aufbau des ERROR-Status-Byte
 ----------------------------
@@ -69,6 +69,27 @@ Aufbau des ERROR-Status-Byte
 3 - OPCODE-ERROR - Der OPCode wurde nicht erkannt
 4 - FIFO Overrun - Der Befehlspuffer im Slave ist noch belegt, derzeit können
                    keine Pakete empfangen werden.
+5 - Address Mismatch - Adress-CRC passt nicht zur Slave-Adresse
+
+Aufbau der Frame-Start-Pakete
+-----------------------------------------
+
++-----------------+---------------+
+| OpCode Addr-CRC | PC | ST | CRC |
++-----------------+---------------+
+
+OpCode:  5 bit OpCode (siehe unten)
+Addr-CRC:3 bit CRC über die Slave-Adresse nach Padding
+
+        Addr-CRC wird über folgende 16 Bit berechnet:
+
+              +-------------+-----------+
+              | I2C address | 00000 CRC |
+              +-------------+-----------+
+
+              CRC ist 000 bei der Berechnung im Master und kann im Slave auf die
+              übermittelte Adress-CRC gesetzt werden, um die Validität der
+              Frame-Adresse zu bestätigen.
 
 
 
@@ -344,4 +365,4 @@ OPCodes
 5 Firmware-Update Management (mit Sub-Kommando etc im Frame)
 6 Firmware-Update Daten
 7-15 RESERVIERT
-16-255 Applikationsspezifisch
+16-31 Applikationsspezifisch

--- a/Documentation/protocol.txt
+++ b/Documentation/protocol.txt
@@ -358,11 +358,11 @@ Ablauf von Kommunikation im Fehlerfall
 OPCodes
 =======
 
-1 Reset bewirkt einen Reboot des Clients.
-2 Statusabfrage Mit Daten über den Application Status
-3 Register lesen
-4 Register schreiben
-5 Firmware-Update Management (mit Sub-Kommando etc im Frame)
-6 Firmware-Update Daten
-7-15 RESERVIERT
+1     Reset bewirkt einen Reboot des Clients.
+2     Statusabfrage Mit Daten über den Application Status
+3     Register lesen
+4     Register schreiben
+5     Firmware-Update Management (mit Sub-Kommando etc im Frame)
+6     Firmware-Update Daten
+7-15  RESERVIERT
 16-31 Applikationsspezifisch


### PR DESCRIPTION
Wenn es einen Bitfehler gibt, wärend auf dem Bus die
Slave-adresse übertragen wird, bekommt uU ein falscher Slave das Paket - und
reagiert darauf.

Insbesondere bei einem Frame, der nur ein Paket lang ist, erfährt der Master
nie, dass er den falschen Slave angesprochen hat.

Zwei Lösungsmöglichkeiten:
1) Man verwendet nur Adressen mit einem gewissen Hamming-Absstand. Dann
verliert man einiges an Bus-Adressen, vllt reicht es aber trotzdem noch.
2) Man kodiert den Empfänger (Slave) eines Datenpakets in den Frame.

In diesem PR ist die Idee für 2)
        Im Frame-Start machen wir den OpCode doch nur 5 Bit lang und
codieren in die verbleibenden 3 Bit wieder ein CRC – diesmal über die
Slave-Adresse. Damit die vorhandene Funktion verwendet werden kann, padden
wir den auf 16 Bit (bzw 13 Bit – je nach Betrachtungsweise).

Für den Fall, dass in der Adress-Codierung Bit-Fehler auf dem I2C-Bus
entstehen, gibt es jetzt zwei Fälle:
I) Es handelt sich um ein Start-Paket (entsprechender Status), dann stimmt
die CRC des Empfängers nicht und das Paket wird mit einem Fehler
beantwortet. Dazu führen wir einen Fehlerstatus ein:
        Recipiend Address Mismatch
II) Es handelt sich um ein Datenpaket – dann ergibt sich unter der
Voraussetzung, dass wir Frames nicht splitten (also nicht interleaved zwei
Frames an zwei verschiedene Slaves schicken) ein Frame Error, weil Daten
ohne ein Start-Paket gesendet wurden.

Selbst wenn wir nur 16 applikationsspezifische Kommandos zulassen, reicht
das noch für unsere Anwendungen.
